### PR TITLE
Only initiate plugin when WP is not installing

### DIFF
--- a/mime_type_link_images.php
+++ b/mime_type_link_images.php
@@ -2157,7 +2157,9 @@ if ( ! class_exists( 'Mime_Types_Link_Icons' ) ) {
 
 
 	/* Instantiate our class */
-	add_action( 'plugins_loaded', 'mimetypes_link_icons_init' );
+	if ( ! defined( 'WP_INSTALLING' ) || WP_INSTALLING === false ) {
+		add_action( 'plugins_loaded', 'mimetypes_link_icons_init' );
+	}
 
 	if ( ! function_exists( 'mimetypes_link__icons_init' ) ) {
 		/**


### PR DESCRIPTION
While I haven't seen any issues reported, this could prevent them all the same.