### PR TITLE
Allow for the new wp_installing() function.

### DIFF
--- a/mime_type_link_images.php
+++ b/mime_type_link_images.php
@@ -2170,7 +2170,7 @@ if ( ! class_exists( 'Mime_Types_Link_Icons' ) ) {
 
 
 	/* Instantiate our class */
-	if ( ! defined( 'WP_INSTALLING' ) || WP_INSTALLING === false ) {
+	if ( ( function_exists( 'wp_installing' ) && wp_installing() === false ) || ( ! function_exists( 'wp_installing' ) && ( ! defined( 'WP_INSTALLING' ) || WP_INSTALLING === false ) ) ) {
 		add_action( 'plugins_loaded', 'mimetypes_link_icons_init' );
 	}
 


### PR DESCRIPTION
Introduced in WP 4.4.
See: https://core.trac.wordpress.org/changeset/34828
